### PR TITLE
Avoid sending moot page and column addresses

### DIFF
--- a/mipi_display.c
+++ b/mipi_display.c
@@ -107,25 +107,38 @@ static void mipi_display_read_data(uint8_t *data, size_t length)
 static void mipi_display_set_address(uint16_t x1, uint16_t y1, uint16_t x2, uint16_t y2) {
     uint8_t command;
     uint8_t data[4];
+    static uint16_t prev_x1, prev_x2, prev_y1, prev_y2;
 
     x1 = x1 + MIPI_DISPLAY_OFFSET_X;
     y1 = y1 + MIPI_DISPLAY_OFFSET_Y;
     x2 = x2 + MIPI_DISPLAY_OFFSET_X;
     y2 = y2 + MIPI_DISPLAY_OFFSET_Y;
 
-    mipi_display_write_command(MIPI_DCS_SET_COLUMN_ADDRESS);
-    data[0] = x1 >> 8;
-    data[1] = x1 & 0xff;
-    data[2] = x2 >> 8;
-    data[3] = x2 & 0xff;
-    mipi_display_write_data(data, 4);
+    /* Change column address only if it has changed. */
+    if ((prev_x1 != x1 || prev_x2 != x2)) {
+        mipi_display_write_command(MIPI_DCS_SET_COLUMN_ADDRESS);
+        data[0] = x1 >> 8;
+        data[1] = x1 & 0xff;
+        data[2] = x2 >> 8;
+        data[3] = x2 & 0xff;
+        mipi_display_write_data(data, 4);
 
-    mipi_display_write_command(MIPI_DCS_SET_PAGE_ADDRESS);
-    data[0] = y1 >> 8;
-    data[1] = y1 & 0xff;
-    data[2] = y2 >> 8;
-    data[3] = y2 & 0xff;
-    mipi_display_write_data(data, 4);
+        prev_x1 = x1;
+        prev_x2 = x2;
+    }
+
+    /* Change page address only if it has changed. */
+    if ((prev_y1 != y1 || prev_y2 != y2)) {
+        mipi_display_write_command(MIPI_DCS_SET_PAGE_ADDRESS);
+        data[0] = y1 >> 8;
+        data[1] = y1 & 0xff;
+        data[2] = y2 >> 8;
+        data[3] = y2 & 0xff;
+        mipi_display_write_data(data, 4);
+
+        prev_y1 = y1;
+        prev_y2 = y2;
+    }
 
     mipi_display_write_command(MIPI_DCS_WRITE_MEMORY_START);
 }


### PR DESCRIPTION
Do not sent page and column addresses when they have not changed. This helps especially with filled rectangles where only the y coordinates change in a loop.
