### PR TITLE
Add support for triple buffering

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ target_sources(hagl_hal INTERFACE
   ${CMAKE_CURRENT_LIST_DIR}/mipi_display.c
   ${CMAKE_CURRENT_LIST_DIR}/hagl_hal_single.c
   ${CMAKE_CURRENT_LIST_DIR}/hagl_hal_double.c
+  ${CMAKE_CURRENT_LIST_DIR}/hagl_hal_triple.c
 )
 
 target_include_directories(hagl_hal INTERFACE ${CMAKE_CURRENT_LIST_DIR}/include)

--- a/README.md
+++ b/README.md
@@ -33,12 +33,23 @@ target_compile_definitions(firmware PRIVATE
 )
 ```
 
-By default flushing from back buffer to front buffer is a locking operation. You can avoid that by enabling DMA. This is faster but will cause screen tearing unless you handle vertical syncing somehow in the software.
+By default flushing from back buffer to front buffer is a locking operation. You can avoid that by enabling DMA. This is faster but will cause screen tearing unless you handle vertical syncing in the software.
 
 ```
 target_compile_definitions(firmware PRIVATE
   NO_MENUCONFIG
   HAGL_HAL_USE_DOUBLE_BUFFER
+  HAGL_HAL_USE_DMA
+)
+```
+
+Alternatively you can also use triple buffering. This is the fastest and will not have screen tearing with DMA. Downside is that it uses lot of memory.
+
+
+```
+target_compile_definitions(firmware PRIVATE
+  NO_MENUCONFIG
+  HAGL_HAL_USE_TRIPLE_BUFFER
   HAGL_HAL_USE_DMA
 )
 ```
@@ -49,25 +60,25 @@ The default config can be found in `hagl_hal.h`. Defaults are ok for Pimoroni Pi
 
 Below testing was done with Pimoroni Pico Display Pack. Double buffering refresh rate was set to 30 frames per second. Number represents operations per seconsd ie. bigger number is better.
 
-|                               | Single | Double    | Double DMA |
-|-------------------------------|--------|-----------|------------|
-| hagl_put_pixel()              | 104919 |    229668 |     328069 |
-| hagl_draw_line()              |   1602 |     10688 |      15311 |
-| hagl_draw_vline()             |  36079 |     37557 |      53787 |
-| hagl_draw_hline()             |  36070 |     37622 |      54001 |
-| hagl_draw_circle()            |   1610 |     14925 |      21412 |
-| hagl_fill_circle()            |   1267 |      7201 |      10281 |
-| hagl_draw_ellipse()           |    965 |      8179 |      11696 |
-| hagl_fill_ellipse()           |    492 |      2790 |       4021 |
-| hagl_draw_triangle()          |    535 |      3661 |       5230 |
-| hagl_fill_triangle()          |    346 |       499 |        711 |
-| hagl_draw_rectangle()         |   8989 |     12168 |      17425 |
-| hagl_fill_rectangle()         |    611 |      3979 |       5752 |
-| hagl_draw_rounded_rectangle() |   3552 |     10802 |      15417 |
-| hagl_fill_rounded_rectangle() |    569 |      3664 |       5271 |
-| hagl_draw_polygon()           |    322 |      2211 |       3170 |
-| hagl_fill_polygon()           |    178 |       221 |        315 |
-| hagl_put_char()               |  19664 |     19364 |      27753 |
+|                               | Single | Double    | Double DMA | Triple DMA |
+|-------------------------------|--------|-----------|------------|------------|
+| hagl_put_pixel()              | 104919 |    229668 |     328069 |     328080 |
+| hagl_draw_line()              |   1602 |     10688 |      15311 |      15313 |
+| hagl_draw_vline()             |  36079 |     37557 |      53787 |      53877 |
+| hagl_draw_hline()             |  36070 |     37622 |      54001 |      53951 |
+| hagl_draw_circle()            |   1610 |     14925 |      21412 |      21403 |
+| hagl_fill_circle()            |   1267 |      7201 |      10281 |      10320 |
+| hagl_draw_ellipse()           |    965 |      8179 |      11696 |      11715 |
+| hagl_fill_ellipse()           |    492 |      2790 |       4021 |       2005 |
+| hagl_draw_triangle()          |    535 |      3661 |       5230 |       5263 |
+| hagl_fill_triangle()          |    346 |       499 |        711 |        716 |
+| hagl_draw_rectangle()         |   8989 |     12168 |      17425 |      17420 |
+| hagl_fill_rectangle()         |    611 |      3979 |       5752 |       5739 |
+| hagl_draw_rounded_rectangle() |   3552 |     10802 |      15417 |      15468 |
+| hagl_fill_rounded_rectangle() |    569 |      3664 |       5271 |       5259 |
+| hagl_draw_polygon()           |    322 |      2211 |       3170 |       3170 |
+| hagl_fill_polygon()           |    178 |       221 |        315 |        319 |
+| hagl_put_char()               |  19664 |     19364 |      27753 |      27988 |
 
 ## License
 

--- a/hagl_hal_triple.c
+++ b/hagl_hal_triple.c
@@ -33,7 +33,7 @@ SPDX-License-Identifier: MIT
 
 This is the HAL used when triple buffering is enabled. The GRAM of the
 display driver chip is the framebuffer. The two memory blocks allocated
-by this HAL are the two back buffer. Total three buffers.
+by this HAL are the two back buffers. Total three buffers.
 
 Note that all coordinates are already clipped in the main library itself.
 HAL does not need to validate the coordinates, they can alway be assumed

--- a/hagl_hal_triple.c
+++ b/hagl_hal_triple.c
@@ -1,0 +1,130 @@
+/*
+
+MIT License
+
+Copyright (c) 2019-2021 Mika Tuupola
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+-cut-
+
+This file is part of the Raspberry Pi Pico HAL for the HAGL graphics library:
+https://github.com/tuupola/hagl_pico_mipi
+
+SPDX-License-Identifier: MIT
+
+-cut-
+
+This is the HAL used when triple buffering is enabled. The GRAM of the
+display driver chip is the framebuffer. The two memory blocks allocated
+by this HAL are the two back buffer. Total three buffers.
+
+Note that all coordinates are already clipped in the main library itself.
+HAL does not need to validate the coordinates, they can alway be assumed
+valid.
+
+
+*/
+
+#include "hagl_hal.h"
+
+#ifdef HAGL_HAL_USE_TRIPLE_BUFFER
+
+#include <string.h>
+#include <mipi_display.h>
+#include <mipi_dcs.h>
+
+#include <bitmap.h>
+#include <hagl.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+
+static uint8_t buffer1[BITMAP_SIZE(DISPLAY_WIDTH, DISPLAY_HEIGHT, DISPLAY_DEPTH)];
+static uint8_t buffer2[BITMAP_SIZE(DISPLAY_WIDTH, DISPLAY_HEIGHT, DISPLAY_DEPTH)];
+
+static bitmap_t fb = {
+    .width = DISPLAY_WIDTH,
+    .height = DISPLAY_HEIGHT,
+    .depth = DISPLAY_DEPTH,
+};
+
+bitmap_t *hagl_hal_init(void)
+{
+    mipi_display_init();
+    bitmap_init(&fb, buffer2);
+    bitmap_init(&fb, buffer1);
+
+    hagl_hal_debug("Buffer 1 address is %p\n", (void *) buffer1);
+    hagl_hal_debug("Buffer 2 address is %p\n", (void *) buffer2);
+
+    return &fb;
+}
+
+void hagl_hal_flush()
+{
+    uint8_t *buffer = fb.buffer;
+    if (fb.buffer == buffer1) {
+        fb.buffer = buffer2;
+    } else {
+        fb.buffer = buffer1;
+    }
+    /* Flush the current back buffer. */
+    mipi_display_write(0, 0, fb.width, fb.height, (uint8_t *) buffer);
+}
+
+void hagl_hal_put_pixel(int16_t x0, int16_t y0, color_t color)
+{
+    color_t *ptr = (color_t *) (fb.buffer + fb.pitch * y0 + (fb.depth / 8) * x0);
+    *ptr = color;
+}
+
+color_t hagl_hal_get_pixel(int16_t x0, int16_t y0)
+{
+    return *(color_t *) (fb.buffer + fb.pitch * y0 + (fb.depth / 8) * x0);
+}
+
+void hagl_hal_blit(uint16_t x0, uint16_t y0, bitmap_t *src)
+{
+    bitmap_blit(x0, y0, src, &fb);
+}
+
+void hagl_hal_scale_blit(uint16_t x0, uint16_t y0, uint16_t w, uint16_t h, bitmap_t *src)
+{
+    bitmap_scale_blit(x0, y0, w, h, src, &fb);
+}
+
+void hagl_hal_hline(int16_t x0, int16_t y0, uint16_t width, color_t color)
+{
+    color_t *ptr = (color_t *) (fb.buffer + fb.pitch * y0 + (fb.depth / 8) * x0);
+    for (uint16_t x = 0; x < width; x++) {
+        *ptr++ = color;
+    }
+}
+
+void hagl_hal_vline(int16_t x0, int16_t y0, uint16_t height, color_t color)
+{
+    color_t *ptr = (color_t *) (fb.buffer + fb.pitch * y0 + (fb.depth / 8) * x0);
+    for (uint16_t y = 0; y < height; y++) {
+        *ptr = color;
+        ptr += fb.pitch / (fb.depth / 8);
+    }
+}
+
+#endif /* HAGL_HAL_USE_TRIPLE_BUFFER */

--- a/hagl_hal_triple.c
+++ b/hagl_hal_triple.c
@@ -59,7 +59,7 @@ valid.
 static uint8_t buffer1[BITMAP_SIZE(DISPLAY_WIDTH, DISPLAY_HEIGHT, DISPLAY_DEPTH)];
 static uint8_t buffer2[BITMAP_SIZE(DISPLAY_WIDTH, DISPLAY_HEIGHT, DISPLAY_DEPTH)];
 
-static bitmap_t fb = {
+static bitmap_t bb = {
     .width = DISPLAY_WIDTH,
     .height = DISPLAY_HEIGHT,
     .depth = DISPLAY_DEPTH,
@@ -68,51 +68,51 @@ static bitmap_t fb = {
 bitmap_t *hagl_hal_init(void)
 {
     mipi_display_init();
-    bitmap_init(&fb, buffer2);
-    bitmap_init(&fb, buffer1);
+    bitmap_init(&bb, buffer2);
+    bitmap_init(&bb, buffer1);
 
-    hagl_hal_debug("Buffer 1 address is %p\n", (void *) buffer1);
-    hagl_hal_debug("Buffer 2 address is %p\n", (void *) buffer2);
+    hagl_hal_debug("Back buffer 1 address is %p\n", (void *) buffer1);
+    hagl_hal_debug("Back buffer 2 address is %p\n", (void *) buffer2);
 
-    return &fb;
+    return &bb;
 }
 
 void hagl_hal_flush()
 {
-    uint8_t *buffer = fb.buffer;
-    if (fb.buffer == buffer1) {
-        fb.buffer = buffer2;
+    uint8_t *buffer = bb.buffer;
+    if (bb.buffer == buffer1) {
+        bb.buffer = buffer2;
     } else {
-        fb.buffer = buffer1;
+        bb.buffer = buffer1;
     }
     /* Flush the current back buffer. */
-    mipi_display_write(0, 0, fb.width, fb.height, (uint8_t *) buffer);
+    mipi_display_write(0, 0, bb.width, bb.height, (uint8_t *) buffer);
 }
 
 void hagl_hal_put_pixel(int16_t x0, int16_t y0, color_t color)
 {
-    color_t *ptr = (color_t *) (fb.buffer + fb.pitch * y0 + (fb.depth / 8) * x0);
+    color_t *ptr = (color_t *) (bb.buffer + bb.pitch * y0 + (bb.depth / 8) * x0);
     *ptr = color;
 }
 
 color_t hagl_hal_get_pixel(int16_t x0, int16_t y0)
 {
-    return *(color_t *) (fb.buffer + fb.pitch * y0 + (fb.depth / 8) * x0);
+    return *(color_t *) (bb.buffer + bb.pitch * y0 + (bb.depth / 8) * x0);
 }
 
 void hagl_hal_blit(uint16_t x0, uint16_t y0, bitmap_t *src)
 {
-    bitmap_blit(x0, y0, src, &fb);
+    bitmap_blit(x0, y0, src, &bb);
 }
 
 void hagl_hal_scale_blit(uint16_t x0, uint16_t y0, uint16_t w, uint16_t h, bitmap_t *src)
 {
-    bitmap_scale_blit(x0, y0, w, h, src, &fb);
+    bitmap_scale_blit(x0, y0, w, h, src, &bb);
 }
 
 void hagl_hal_hline(int16_t x0, int16_t y0, uint16_t width, color_t color)
 {
-    color_t *ptr = (color_t *) (fb.buffer + fb.pitch * y0 + (fb.depth / 8) * x0);
+    color_t *ptr = (color_t *) (bb.buffer + bb.pitch * y0 + (bb.depth / 8) * x0);
     for (uint16_t x = 0; x < width; x++) {
         *ptr++ = color;
     }
@@ -120,10 +120,10 @@ void hagl_hal_hline(int16_t x0, int16_t y0, uint16_t width, color_t color)
 
 void hagl_hal_vline(int16_t x0, int16_t y0, uint16_t height, color_t color)
 {
-    color_t *ptr = (color_t *) (fb.buffer + fb.pitch * y0 + (fb.depth / 8) * x0);
+    color_t *ptr = (color_t *) (bb.buffer + bb.pitch * y0 + (bb.depth / 8) * x0);
     for (uint16_t y = 0; y < height; y++) {
         *ptr = color;
-        ptr += fb.pitch / (fb.depth / 8);
+        ptr += bb.pitch / (bb.depth / 8);
     }
 }
 

--- a/include/hagl_hal.h
+++ b/include/hagl_hal.h
@@ -45,11 +45,13 @@ typedef uint16_t color_t;
 #define hagl_hal_debug(fmt, ...) \
     do { if (HAGL_HAL_DEBUG) printf("[HAGL HAL] " fmt, __VA_ARGS__); } while (0)
 
-#ifdef HAGL_HAL_USE_DOUBLE_BUFFER
+#if defined(HAGL_HAL_USE_TRIPLE_BUFFER)
+#include "hagl_hal_triple.h"
+#elif defined(HAGL_HAL_USE_DOUBLE_BUFFER)
 #include "hagl_hal_double.h"
 #else
 #include "hagl_hal_single.h"
-#endif
+#endif /* HAGL_HAL_USE_TRIPLE_BUFFER */
 
 /* Default config is ok for Pimoroni Pico Display Pack. When compiling */
 /* you can override these by including an user config header file first. */

--- a/include/hagl_hal_triple.h
+++ b/include/hagl_hal_triple.h
@@ -33,7 +33,7 @@ SPDX-License-Identifier: MIT
 
 This is the HAL used when triple buffering is enabled. The GRAM of the
 display driver chip is the framebuffer. The two memory blocks allocated
-by this HAL are the two back buffer. Total three buffers.
+by this HAL are the two back buffers. Total three buffers.
 
 Note that all coordinates are already clipped in the main library itself.
 HAL does not need to validate the coordinates, they can alway be assumed

--- a/include/hagl_hal_triple.h
+++ b/include/hagl_hal_triple.h
@@ -31,9 +31,9 @@ SPDX-License-Identifier: MIT
 
 -cut-
 
-This is the HAL used when double buffering is enabled. The GRAM of the
-display driver chip is the framebuffer. The memory allocated by this HAL
-is the back buffer. Total two buffers.
+This is the HAL used when triple buffering is enabled. The GRAM of the
+display driver chip is the framebuffer. The two memory blocks allocated
+by this HAL are the two back buffer. Total three buffers.
 
 Note that all coordinates are already clipped in the main library itself.
 HAL does not need to validate the coordinates, they can alway be assumed
@@ -41,8 +41,8 @@ valid.
 
 */
 
-#ifndef _HAGL_HAL_DOUBLE_H
-#define _HAGL_HAL_DOUBLE_H
+#ifndef _HAGL_HAL_TRIPLE_H
+#define _HAGL_HAL_TRIPLE_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -52,9 +52,9 @@ extern "C" {
 #include <bitmap.h>
 
 /* Define if header file included directly. */
-#ifndef HAGL_HAL_USE_DOUBLE_BUFFER
-#define HAGL_HAL_USE_DOUBLE_BUFFER
-#endif /* HAGL_HAL_USE_DOUBLE_BUFFER */
+#ifndef HAGL_HAL_USE_TRIPLE_BUFFER
+#define HAGL_HAL_USE_TRIPLE_BUFFER
+#endif /* HAGL_HAL_USE_TRIPLE_BUFFER */
 
 #include "hagl_hal.h"
 
@@ -141,4 +141,4 @@ void hagl_hal_flush();
 #ifdef __cplusplus
 }
 #endif
-#endif /* _HAGL_HAL_DOUBLE_H */
+#endif /* _HAGL_HAL_TRIPLE_H */

--- a/mipi_display.c
+++ b/mipi_display.c
@@ -182,10 +182,16 @@ static void mipi_display_spi_master_init()
 
 void mipi_display_init()
 {
+#ifdef HAGL_HAL_USE_SINGLE_BUFFER
+    hagl_hal_debug("%s\n", "Initialising single buffered display.");
+#endif /* HAGL_HAL_USE_SINGLE_BUFFER */
+
 #ifdef HAGL_HAL_USE_DOUBLE_BUFFER
     hagl_hal_debug("%s\n", "Initialising double buffered display.");
-#else
-    hagl_hal_debug("%s\n", "Initialising single buffered display.");
+#endif /* HAGL_HAL_USE_DOUBLE_BUFFER */
+
+#ifdef HAGL_HAL_USE_TRIPLE_BUFFER
+    hagl_hal_debug("%s\n", "Initialising triple buffered display.");
 #endif /* HAGL_HAL_USE_DOUBLE_BUFFER */
 
     /* Init the spi driver. */
@@ -236,11 +242,11 @@ void mipi_display_init()
     /* Set the default viewport to full screen. */
     mipi_display_set_address(0, 0, MIPI_DISPLAY_WIDTH - 1, MIPI_DISPLAY_HEIGHT - 1);
 
-#ifdef HAGL_HAL_USE_DOUBLE_BUFFER
+#ifdef HAGL_HAS_HAL_BACK_BUFFER
 #ifdef HAGL_HAL_USE_DMA
     mipi_display_dma_init();
 #endif /* HAGL_HAL_USE_DMA */
-#endif /* HAGL_HAL_USE_DOUBLE_BUFFER */
+#endif /* HAGL_HAS_HAL_BACK_BUFFER */
 }
 
 void mipi_display_write(uint16_t x1, uint16_t y1, uint16_t w, uint16_t h, uint8_t *buffer)
@@ -258,14 +264,14 @@ void mipi_display_write(uint16_t x1, uint16_t y1, uint16_t w, uint16_t h, uint8_
     mipi_display_write_data(buffer, size * DISPLAY_DEPTH / 8);
 #endif /* HAGL_HAL_SINGLE_BUFFER */
 
-#ifdef HAGL_HAL_USE_DOUBLE_BUFFER
-    mipi_display_set_address(x1, y1, x2, y2);
+#ifdef HAGL_HAS_HAL_BACK_BUFFER
+    //mipi_display_set_address(x1, y1, x2, y2);
 #ifdef HAGL_HAL_USE_DMA
     mipi_display_write_data_dma(buffer, size * DISPLAY_DEPTH / 8);
 #else
     mipi_display_write_data(buffer, size * DISPLAY_DEPTH / 8);
 #endif /* HAGL_HAL_USE_DMA */
-#endif /* HAGL_HAL_USE_DOUBLE_BUFFER */
+#endif /* HAGL_HAS_HAL_BACK_BUFFER */
 }
 
 /* TODO: This most likely does not work with dma atm. */


### PR DESCRIPTION
The GRAM of the display driver chip is the frame buffer. The two memory blocks allocated by this HAL are the two back buffers. Total three buffers.