### PR TITLE
Fix MIPI_DISPLAY_INVERT setting

### DIFF
--- a/include/hagl_hal.h
+++ b/include/hagl_hal.h
@@ -87,9 +87,14 @@ typedef uint16_t color_t;
 #ifndef MIPI_DISPLAY_ADDRESS_MODE
 #define MIPI_DISPLAY_ADDRESS_MODE   (MIPI_DCS_ADDRESS_MODE_RGB)
 #endif
+
+/* Default to invert because Pimoroni Pico Display Pack needs it. */
 #ifndef MIPI_DISPLAY_INVERT
 #define MIPI_DISPLAY_INVERT
+#elif MIPI_DISPLAY_INVERT == 0
+#undef MIPI_DISPLAY_INVERT
 #endif
+
 #ifndef MIPI_DISPLAY_WIDTH
 #define MIPI_DISPLAY_WIDTH          (135)
 #endif

--- a/mipi_display.c
+++ b/mipi_display.c
@@ -221,6 +221,7 @@ void mipi_display_init()
 
 #ifdef MIPI_DISPLAY_INVERT
     mipi_display_write_command(MIPI_DCS_ENTER_INVERT_MODE);
+    hagl_hal_debug("%s\n", "Inverting display.");
 #else
     mipi_display_write_command(MIPI_DCS_EXIT_INVERT_MODE);
 #endif


### PR DESCRIPTION
Defaults to be on because Pimoroni Pico Display Pack nees it. 
Turn off by setting to zero.

```
target_compile_definitions(firmware PRIVATE
  MIPI_DISPLAY_INVERT=0
)
```