### PR TITLE
Allow passing buffers to HAL initialisation

### DIFF
--- a/hagl_hal_double.c
+++ b/hagl_hal_double.c
@@ -123,10 +123,10 @@ hagl_hal_init(hagl_backend_t *backend)
     mipi_display_init();
 
     if (!backend->buffer) {
-        backend->buffer = malloc(DISPLAY_WIDTH * DISPLAY_HEIGHT * (DISPLAY_DEPTH / 8));
-        hagl_hal_debug("Allocated back buffer to address %p.", (void *) backend->buffer);
+        backend->buffer = calloc(sizeof(uint8_t), DISPLAY_WIDTH * DISPLAY_HEIGHT * (DISPLAY_DEPTH / 8));
+        hagl_hal_debug("Allocated back buffer to address %p.\n", (void *) backend->buffer);
     } else {
-        hagl_hal_debug("Using provided back buffer at address %p.", (void *) backend->buffer);
+        hagl_hal_debug("Using provided back buffer at address %p.\n", (void *) backend->buffer);
     }
 
     bitmap_init(&fb, backend->buffer);

--- a/hagl_hal_double.c
+++ b/hagl_hal_double.c
@@ -63,7 +63,7 @@ static bitmap_t fb = {
 };
 
 static size_t
-flush()
+flush(void *backend)
 {
     /* Flush the whole back buffer. */
     return mipi_display_write(0, 0, fb.width, fb.height, (uint8_t *) fb.buffer);
@@ -123,7 +123,6 @@ hagl_hal_init(hagl_backend_t *backend)
     mipi_display_init();
 
     if (!backend->buffer) {
-        size_t size =
         backend->buffer = malloc(DISPLAY_WIDTH * DISPLAY_HEIGHT * (DISPLAY_DEPTH / 8));
         hagl_hal_debug("Allocated back buffer to address %p.", (void *) backend->buffer);
     } else {

--- a/hagl_hal_double.c
+++ b/hagl_hal_double.c
@@ -105,18 +105,6 @@ vline(int16_t x0, int16_t y0, uint16_t height, color_t color)
     bitmap_vline(&fb, x0, y0, height, color);
 }
 
-static int16_t
-width()
-{
-    return MIPI_DISPLAY_WIDTH;
-}
-
-static int16_t
-height()
-{
-    return MIPI_DISPLAY_HEIGHT;
-}
-
 void
 hagl_hal_init(hagl_backend_t *backend)
 {
@@ -131,8 +119,9 @@ hagl_hal_init(hagl_backend_t *backend)
 
     bitmap_init(&fb, backend->buffer);
 
-    backend->width = width;
-    backend->height = height;
+    backend->width = MIPI_DISPLAY_WIDTH;
+    backend->height = MIPI_DISPLAY_HEIGHT;
+    backend->depth = MIPI_DISPLAY_DEPTH;
     backend->put_pixel = put_pixel;
     backend->hline = hline;
     backend->vline = vline;

--- a/hagl_hal_double.c
+++ b/hagl_hal_double.c
@@ -56,8 +56,6 @@ assumed to be valid.
 #include <stdio.h>
 #include <stdlib.h>
 
-static uint8_t buffer[BITMAP_SIZE(DISPLAY_WIDTH, DISPLAY_HEIGHT, DISPLAY_DEPTH)];
-
 static bitmap_t fb = {
     .width = DISPLAY_WIDTH,
     .height = DISPLAY_HEIGHT,
@@ -123,9 +121,16 @@ void
 hagl_hal_init(hagl_backend_t *backend)
 {
     mipi_display_init();
-    bitmap_init(&fb, buffer);
 
-    hagl_hal_debug("Back buffer address is %p\n", (void *) buffer);
+    if (!backend->buffer) {
+        size_t size =
+        backend->buffer = malloc(DISPLAY_WIDTH * DISPLAY_HEIGHT * (DISPLAY_DEPTH / 8));
+        hagl_hal_debug("Allocated back buffer to address %p.", (void *) backend->buffer);
+    } else {
+        hagl_hal_debug("Using provided back buffer at address %p.", (void *) backend->buffer);
+    }
+
+    bitmap_init(&fb, backend->buffer);
 
     backend->width = width;
     backend->height = height;

--- a/hagl_hal_double.c
+++ b/hagl_hal_double.c
@@ -111,7 +111,7 @@ hagl_hal_init(hagl_backend_t *backend)
     mipi_display_init();
 
     if (!backend->buffer) {
-        backend->buffer = calloc(sizeof(uint8_t), DISPLAY_WIDTH * DISPLAY_HEIGHT * (DISPLAY_DEPTH / 8));
+        backend->buffer = calloc(DISPLAY_WIDTH * DISPLAY_HEIGHT * (DISPLAY_DEPTH / 8), sizeof(uint8_t));
         hagl_hal_debug("Allocated back buffer to address %p.\n", (void *) backend->buffer);
     } else {
         hagl_hal_debug("Using provided back buffer at address %p.\n", (void *) backend->buffer);

--- a/hagl_hal_double.c
+++ b/hagl_hal_double.c
@@ -119,27 +119,21 @@ height()
     return MIPI_DISPLAY_HEIGHT;
 }
 
-hagl_backend_t *
-hagl_hal_init(void)
+void
+hagl_hal_init(hagl_backend_t *backend)
 {
     mipi_display_init();
     bitmap_init(&fb, buffer);
 
     hagl_hal_debug("Back buffer address is %p\n", (void *) buffer);
 
-    static hagl_backend_t backend;
+    backend->width = width;
+    backend->height = height;
+    backend->put_pixel = put_pixel;
+    backend->hline = hline;
+    backend->vline = vline;
 
-    memset(&backend, 0, sizeof(hagl_backend_t));
-
-    backend.width = width;
-    backend.height = height;
-    backend.put_pixel = put_pixel;
-    backend.hline = hline;
-    backend.vline = vline;
-
-    backend.flush = flush;
-
-    return &backend;
+    backend->flush = flush;
 }
 
 #endif /* HAGL_HAL_USE_DOUBLE_BUFFER */

--- a/hagl_hal_single.c
+++ b/hagl_hal_single.c
@@ -102,22 +102,16 @@ height()
     return MIPI_DISPLAY_HEIGHT;
 }
 
-hagl_backend_t *
-hagl_hal_init(void)
+void
+hagl_hal_init(hagl_backend_t *backend)
 {
     mipi_display_init();
 
-    static hagl_backend_t backend;
-
-    memset(&backend, 0, sizeof(hagl_backend_t));
-
-    backend.width = width;
-    backend.height = height;
-    backend.put_pixel = put_pixel;
-    backend.hline = hline;
-    backend.vline = vline;
-
-    return &backend;
+    backend->width = width;
+    backend->height = height;
+    backend->put_pixel = put_pixel;
+    backend->hline = hline;
+    backend->vline = vline;
 }
 
 #endif /* HAGL_HAL_USE_SINGLE_BUFFER */

--- a/hagl_hal_single.c
+++ b/hagl_hal_single.c
@@ -90,25 +90,14 @@ vline(int16_t x0, int16_t y0, uint16_t height, color_t color)
     mipi_display_write(x0, y0, width, height, (uint8_t *) line);
 }
 
-static int16_t
-width()
-{
-    return MIPI_DISPLAY_WIDTH;
-}
-
-static int16_t
-height()
-{
-    return MIPI_DISPLAY_HEIGHT;
-}
-
 void
 hagl_hal_init(hagl_backend_t *backend)
 {
     mipi_display_init();
 
-    backend->width = width;
-    backend->height = height;
+    backend->width = MIPI_DISPLAY_WIDTH;
+    backend->height = MIPI_DISPLAY_HEIGHT;
+    backend->depth = MIPI_DISPLAY_DEPTH;
     backend->put_pixel = put_pixel;
     backend->hline = hline;
     backend->vline = vline;

--- a/hagl_hal_triple.c
+++ b/hagl_hal_triple.c
@@ -121,14 +121,14 @@ hagl_hal_init(hagl_backend_t *backend)
     mipi_display_init();
 
     if (!backend->buffer) {
-        backend->buffer = calloc(sizeof(uint8_t), DISPLAY_WIDTH * DISPLAY_HEIGHT * (DISPLAY_DEPTH / 8));
+        backend->buffer = calloc(DISPLAY_WIDTH * DISPLAY_HEIGHT * (DISPLAY_DEPTH / 8), sizeof(uint8_t));
         hagl_hal_debug("Allocated first back buffer to address %p.\n", (void *) backend->buffer);
     } else {
         hagl_hal_debug("Using provided first back buffer at address %p.\n", (void *) backend->buffer);
     }
 
     if (!backend->buffer2) {
-        backend->buffer2 = calloc(sizeof(uint8_t), DISPLAY_WIDTH * DISPLAY_HEIGHT * (DISPLAY_DEPTH / 8));
+        backend->buffer2 = calloc(DISPLAY_WIDTH * DISPLAY_HEIGHT * (DISPLAY_DEPTH / 8), sizeof(uint8_t));
         hagl_hal_debug("Allocated second back buffer to address %p.\n", (void *) backend->buffer2);
     } else {
         hagl_hal_debug("Using provided second back buffer at address %p.\n", (void *) backend->buffer2);

--- a/hagl_hal_triple.c
+++ b/hagl_hal_triple.c
@@ -115,18 +115,6 @@ vline(int16_t x0, int16_t y0, uint16_t height, color_t color)
     bitmap_vline(&bb, x0, y0, height, color);
 }
 
-static int16_t
-width()
-{
-    return MIPI_DISPLAY_WIDTH;
-}
-
-static int16_t
-height()
-{
-    return MIPI_DISPLAY_HEIGHT;
-}
-
 void
 hagl_hal_init(hagl_backend_t *backend)
 {
@@ -149,8 +137,9 @@ hagl_hal_init(hagl_backend_t *backend)
     /* Initially use the first buffer. */
     bitmap_init(&bb, backend->buffer);
 
-    backend->width = width;
-    backend->height = height;
+    backend->width = MIPI_DISPLAY_WIDTH;
+    backend->height = MIPI_DISPLAY_HEIGHT;
+    backend->depth = MIPI_DISPLAY_DEPTH;
     backend->put_pixel = put_pixel;
     backend->hline = hline;
     backend->vline = vline;

--- a/hagl_hal_triple.c
+++ b/hagl_hal_triple.c
@@ -126,8 +126,8 @@ height()
     return MIPI_DISPLAY_HEIGHT;
 }
 
-hagl_backend_t *
-hagl_hal_init(void)
+void
+hagl_hal_init(hagl_backend_t *backend)
 {
     mipi_display_init();
     bitmap_init(&bb, buffer2);
@@ -136,19 +136,13 @@ hagl_hal_init(void)
     hagl_hal_debug("Back buffer 1 address is %p\n", (void *) buffer1);
     hagl_hal_debug("Back buffer 2 address is %p\n", (void *) buffer2);
 
-    static hagl_backend_t backend;
+    backend->width = width;
+    backend->height = height;
+    backend->put_pixel = put_pixel;
+    backend->hline = hline;
+    backend->vline = vline;
 
-    memset(&backend, 0, sizeof(hagl_backend_t));
-
-    backend.width = width;
-    backend.height = height;
-    backend.put_pixel = put_pixel;
-    backend.hline = hline;
-    backend.vline = vline;
-
-    backend.flush = flush;
-
-    return &backend;
+    backend->flush = flush;
 }
 
 #endif /* HAGL_HAL_USE_TRIPLE_BUFFER */

--- a/include/hagl_hal_double.h
+++ b/include/hagl_hal_double.h
@@ -64,10 +64,8 @@ extern "C" {
 
 /**
  * Initialize the HAL
- *
- * @return pointer to the backend
  */
-hagl_backend_t *hagl_hal_init(void);
+void hagl_hal_init(hagl_backend_t *backend);
 
 #ifdef __cplusplus
 }

--- a/include/hagl_hal_single.h
+++ b/include/hagl_hal_single.h
@@ -59,12 +59,8 @@ extern "C" {
 
 /**
  * Initialize the HAL
- *
- * This HAL returns null since it does not use buffering.
- *
- * @return NULL
  */
-hagl_backend_t *hagl_hal_init(void);
+void hagl_hal_init(hagl_backend_t *backend);
 
 #ifdef __cplusplus
 }

--- a/include/hagl_hal_triple.h
+++ b/include/hagl_hal_triple.h
@@ -65,10 +65,8 @@ extern "C" {
 
 /**
  * Initialize the backend
- *
- * @return pointer to he backend instance
  */
-hagl_backend_t *hagl_hal_init(void);
+void hagl_hal_init(hagl_backend_t *backend);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
So you can either do it the easy way:

```c
hagl_backend_t *backend = hagl_init();
```

Or provide buffers and in the future other configuration manually.

```c
hagl_backend_t backend;
memset(&backend, 0, sizeof(hagl_backend_t));
backend.buffer = malloc(DISPLAY_WIDTH * DISPLAY_HEIGHT * (DISPLAY_DEPTH / 8));
hagl_hal_init(&backend);
```