### PR TITLE
Add naive implementation of pixel size

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,17 @@ target_compile_definitions(firmware PRIVATE
 )
 ```
 
+If you run out of memory you could try using bigger pixel size. For example if you have 240x240 pixel display and you want to try triple buffering you could do the following. In practice it will change your usable resolution to 120x120 pixels.
+
+Note! At the time of writing `HAGL_HAL_PIXEL_SIZE=2` will not work together with the `HAGL_HAL_USE_DMA` setting.
+
+```
+target_compile_definitions(firmware PRIVATE
+  HAGL_HAL_USE_TRIPLE_BUFFER
+  HAGL_HAL_PIXEL_SIZE=2
+)
+```
+
 The default config can be found in `hagl_hal.h`. Defaults are ok for [Pimoroni Pico Display Pack](https://shop.pimoroni.com/products/pico-display-pack) in vertical mode.
 
 ## Configuration
@@ -59,21 +70,24 @@ You can override any of the default settings setting in `CMakeLists.txt`. You on
 
 ```
 target_compile_definitions(firmware PRIVATE
-  MIPI_DISPLAY_SPI_CLOCK_SPEED_HZ=64000000
-  MIPI_DISPLAY_PIN_CS=17
-  MIPI_DISPLAY_PIN_DC=16
-  MIPI_DISPLAY_PIN_RST=-1
-  MIPI_DISPLAY_PIN_BL=20
-  MIPI_DISPLAY_PIN_CLK=18
-  MIPI_DISPLAY_PIN_MOSI=19
-  MIPI_DISPLAY_PIN_MISO=-1
-  MIPI_DISPLAY_PIXEL_FORMAT=MIPI_DCS_PIXEL_FORMAT_16BIT
-  MIPI_DISPLAY_ADDRESS_MODE=MIPI_DCS_ADDRESS_MODE_RGB
-  MIPI_DISPLAY_WIDTH=135
-  MIPI_DISPLAY_HEIGHT=240
-  MIPI_DISPLAY_OFFSET_X=52
-  MIPI_DISPLAY_OFFSET_Y=40
-  MIPI_DISPLAY_INVERT=0
+    MIPI_DISPLAY_PIN_DC=16
+    MIPI_DISPLAY_PIN_CS=17
+    MIPI_DISPLAY_PIN_CLK=18
+    MIPI_DISPLAY_PIN_MOSI=19
+    MIPI_DISPLAY_PIN_RST=-1
+    MIPI_DISPLAY_PIN_BL=20
+    MIPI_DISPLAY_PIN_MISO=-1
+
+    MIPI_DISPLAY_SPI_PORT=spi0
+    MIPI_DISPLAY_SPI_CLOCK_SPEED_HZ=62500000
+
+    MIPI_DISPLAY_PIXEL_FORMAT=MIPI_DCS_PIXEL_FORMAT_16BIT
+    MIPI_DISPLAY_ADDRESS_MODE=MIPI_DCS_ADDRESS_MODE_RGB
+    MIPI_DISPLAY_WIDTH=135
+    MIPI_DISPLAY_HEIGHT=240
+    MIPI_DISPLAY_OFFSET_X=52
+    MIPI_DISPLAY_OFFSET_Y=40
+    MIPI_DISPLAY_INVERT=1
 )
 ```
 

--- a/hagl_hal_double.c
+++ b/hagl_hal_double.c
@@ -61,8 +61,27 @@ static hagl_bitmap_t bb;
 static size_t
 flush(void *self)
 {
+#if HAGL_HAL_PIXEL_SIZE==1
     /* Flush the whole back buffer. */
     return mipi_display_write(0, 0, bb.width, bb.height, (uint8_t *) bb.buffer);
+#endif /* HAGL_HAL_PIXEL_SIZE==1 */
+
+#if HAGL_HAL_PIXEL_SIZE==2
+    static color_t line[MIPI_DISPLAY_WIDTH];
+
+    color_t *ptr = (color_t *) bb.buffer;
+    size_t sent = 0;
+
+    for (uint16_t y = 0; y < DISPLAY_HEIGHT; y++) {
+        for (uint16_t x = 0; x < DISPLAY_WIDTH; x++) {
+            line[x * 2] = *(ptr);
+            line[x * 2 + 1] = *(ptr++);
+        }
+        sent += mipi_display_write(0, y * 2, MIPI_DISPLAY_WIDTH, 1, (uint8_t *) line);
+        sent += mipi_display_write(0, y * 2 + 1, MIPI_DISPLAY_WIDTH, 1, (uint8_t *) line);
+    }
+    return sent;
+#endif /* HAGL_HAL_PIXEL_SIZE==2 */
 }
 
 static void

--- a/include/hagl_hal.h
+++ b/include/hagl_hal.h
@@ -107,8 +107,12 @@ extern "C" {
 #define MIPI_DISPLAY_OFFSET_Y       (40)
 #endif
 
-#define DISPLAY_WIDTH               (MIPI_DISPLAY_WIDTH)
-#define DISPLAY_HEIGHT              (MIPI_DISPLAY_HEIGHT)
+#ifndef HAGL_HAL_PIXEL_SIZE
+#define HAGL_HAL_PIXEL_SIZE         (1)
+#endif
+
+#define DISPLAY_WIDTH               (MIPI_DISPLAY_WIDTH / HAGL_HAL_PIXEL_SIZE)
+#define DISPLAY_HEIGHT              (MIPI_DISPLAY_HEIGHT / HAGL_HAL_PIXEL_SIZE)
 #define DISPLAY_DEPTH               (MIPI_DISPLAY_DEPTH)
 
 #ifdef HAGL_HAL_USE_TRIPLE_BUFFER

--- a/mipi_display.c
+++ b/mipi_display.c
@@ -275,7 +275,7 @@ size_t mipi_display_write(uint16_t x1, uint16_t y1, uint16_t w, uint16_t h, uint
 #endif /* HAGL_HAL_SINGLE_BUFFER */
 
 #ifdef HAGL_HAS_HAL_BACK_BUFFER
-    //mipi_display_set_address(x1, y1, x2, y2);
+    mipi_display_set_address(x1, y1, x2, y2);
 #ifdef HAGL_HAL_USE_DMA
     mipi_display_write_data_dma(buffer, size * DISPLAY_DEPTH / 8);
 #else


### PR DESCRIPTION
HAGL_HAL_PIXEL_SIZE = 1
HAGL_HAL_PIXEL_SIZE = 2

MIPI_DISPLAY_WIDTH and MIPI_DISPLAY_HEIGHT are the hardware dimensions.
DISPLAY_WIDTH and DISPLAY_WIDTH are the backbuffer dimensions.

Currently unoptimized proof of concept. Mostly used to run memory hungry 
demo effects with larger screens.

Does not work with DMA at the moment.