### PR TITLE
Fix a compile error when HAGL_HAL_DEBUG is not defined

### DIFF
--- a/include/hagl_hal.h
+++ b/include/hagl_hal.h
@@ -43,6 +43,10 @@ extern "C" {
 
 #include "hagl_hal_color.h"
 
+#ifndef HAGL_HAL_DEBUG
+#define HAGL_HAL_DEBUG       (0)
+#endif
+
 #define hagl_hal_debug(fmt, ...) \
     do { if (HAGL_HAL_DEBUG) printf("[HAGL HAL] " fmt, __VA_ARGS__); } while (0)
 


### PR DESCRIPTION
Before this commit, if the user did not define HAGL_HAL_DEBUG the project would fail to compile because `hagl_hal_debug()` was syntactically incorrect.

This commit fixes the error by providing a valid `hagl_hal_debug()` function both when HAGL_HAL_DEBUG is defined and not.  When HAGL_HAL_DEBUG is defined it prints the debug message, just like now.  When HAGL_HAL_DEBUG is not defined, the function does not do anything.