### PR TITLE
Clear the framebuffer in mipi_display_init()

### DIFF
--- a/mipi_display.c
+++ b/mipi_display.c
@@ -288,6 +288,10 @@ mipi_display_init()
     mipi_display_write_command(MIPI_DCS_EXIT_INVERT_MODE);
 #endif /* MIPI_DISPLAY_INVERT */
 
+    /* Clear the framebuffer before turning the display on to avoid snow. */
+    uint16_t black = 0x0000;
+    mipi_display_fill_xywh(0, 0, MIPI_DISPLAY_WIDTH, MIPI_DISPLAY_HEIGHT, (void *)&black);
+
     mipi_display_write_command(MIPI_DCS_EXIT_SLEEP_MODE);
     sleep_ms(200);
 


### PR DESCRIPTION
This initializes the display controller's internal frame buffer to all black before turning the display itself on, to avoid initially displaying random pixels.

I'm not sure that the way I fixed it in this PR is the best way, I'm open to feedback and suggestions.

To demonstrate what I mean, here are two slow-mo videos of the `pico_effects` firmware.  The first one shows the current behavior (hagl_pico_mipi master branch, commit a3abacd3ec), note that the display shows two different "noise" screens at startup, before the demo starts:
 
https://github.com/tuupola/hagl_pico_mipi/assets/400548/42180d57-27bb-43f5-9778-50f13334695b

The first noise screen is due to hagl_hal not clearing the display's frame buffer before turning the display on.  This PR fixes that.  The second noise screen is is from `pico_effects` itself, i'm not going to worry about that ;-)

https://github.com/tuupola/hagl_pico_mipi/assets/400548/0828e348-7e9b-4f83-b836-3dbc7365ce25

